### PR TITLE
Add manual trigger and single TCK test run to Github Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,6 +12,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -23,12 +24,39 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'
+
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build
+
+  run-single:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Prepare and configure TCKs with Gradle (but don't run it)
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: prepareTckTask
+
+    - name: Run a single TCK test
+      run: |
+        ant_bin=$PWD/build/apache-ant-1.10.12/bin/ant
+
+        cd build/messaging-tck/src/com/sun/ts/tests/jms/core
+        ${ant_bin} -Dtest.client=queuetests/QueueTests.java -Dtest=temporaryQueueNotConsumableTest_from_standalone runclient

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,12 +36,23 @@ jobs:
       with:
         arguments: build
 
+  # Executes a single TCK test with qpid-jms against ActiveMQ Artemis to demonstrate the scripts work.
+  # https://github.com/artemiscloud/activemq-artemis-broker-image
+  # https://github.com/apache/qpid-jms
   run-single:
 
     runs-on: ubuntu-latest
 
+    env:
+      artemis_image: quay.io/artemiscloud/activemq-artemis-broker:snapshot
+
     steps:
     - uses: actions/checkout@v3
+
+    - name: Start Artemis Broker in the background
+      run: |
+        podman pull ${{env.artemis_image}}
+        podman run -p 5672:5672 -e AMQ_USER=admin -e AMQ_PASSWORD=admin --rm -it ${{env.artemis_image}} &
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3
@@ -49,7 +60,7 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
-    - name: Prepare and configure TCKs with Gradle (but don't run it)
+    - name: Prepare and configure TCKs with Gradle (but don't run it all)
       uses: gradle/gradle-build-action@v2
       with:
         arguments: prepareTckTask

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Prepare and configure TCKs with Gradle (but don't run it all)
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: prepareTckTask
+        arguments: prepareTckTask --scan
 
     - name: Run a single TCK test
       run: |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The build will *not* fail if applying patch files partially fails.
 
 go to `core/` or `core20/` and run `ant`
 
-    cd build/jmstck/src/com/sun/ts/tests/jms/core
+    cd build/messaging-tck/src/com/sun/ts/tests/jms/core
     ret=0
     while [[ $ret == 0 ]]; do
         ant -Dtest.client=queuetests/QueueTests.java -Dtest=temporaryQueueNotConsumableTest_from_standalone runclient

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,12 +163,12 @@ tasks {
         doLast {
             val properties = getConfigurationProperties(broker = G.jmsBroker, client = G.jmsClient)
             copy {
-                from(resources.resolve("jndi.properties"))
+                from(resources.resolve("jndi.properties").mustExist())
                 into(jndiFileDir)
                 expand(properties)
             }
             copy {
-                from(resources.resolve("log4j.properties"))
+                from(resources.resolve("log4j.properties").mustExist())
                 into(jndiFileDir)
             }
         }
@@ -251,4 +251,12 @@ tasks {
 tasks.wrapper {
     distributionType = Wrapper.DistributionType.BIN
     gradleVersion = "latest"
+}
+
+// https://stackoverflow.com/questions/62889954/copy-task-doesnt-fail-or-log-when-source-file-is-missing
+fun File.mustExist(): File {
+    if (! this.exists()) {
+        throw GradleScriptException("File $this does not exist", Throwable())
+    }
+    return this
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -230,8 +230,12 @@ tasks {
 
     // the main task
 
-    val runTckTask by registering {
+    val prepareTckTask by registering {
         dependsOn(fetchTckTask, patchTckTask, compileTckTask, unzipAntTask)
+    }
+
+    val runTckTask by registering {
+        dependsOn(prepareTckTask)
         doLast {
             exec {
                 executable(antLauncherScript)

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,12 @@
 # limitations under the License.
 #
 
-jmsClientVersion=2.6.0
-jmsVersion=2.0
+# Sample configuration that provides all mandatory -P variables
+# so that the gradle project can be imported into IDE without having to deal
+# with errors caused by undefined variables when evaluating the script.
+
+jmsClientVersion=2.4.0
+upstream=
+jmsVersion=1.1
 jmsBroker=JAMQ7
 jmsClient=mrgm

--- a/src/main/resources/jmstck_config.jakarta.patch
+++ b/src/main/resources/jmstck_config.jakarta.patch
@@ -1,0 +1,56 @@
+diff --git a/bin/ts.jte b/bin/ts.jte
+index 0e0da64..8731745 100644
+--- a/bin/ts.jte
++++ b/bin/ts.jte
+@@ -46,7 +46,11 @@
+ # Standalone JMS RI implementations. The JMS TCK has been run against both.
+ ####################################################################################
+ jms.home=
+-jms.classes=/home/jenkins/agent/workspace/jakartaee-tck_master/modules/jakarta.jms-api.jar:/home/jenkins/agent/workspace/jakartaee-tck_master/modules/glassfish-corba-omgapi.jar
++
++#### BEGIN changes ####
++#jms.classes=/home/jenkins/agent/workspace/jakartaee-tck_master/modules/jakarta.jms-api.jar:/home/jenkins/agent/workspace/jakartaee-tck_master/modules/glassfish-corba-omgapi.jar
++jms.classes=@client_libs@
++#### END changes ####
+
+ ####################################################################################
+ # The jars/classes for the TS harness/javatest and the test classes
+@@ -108,8 +112,14 @@ harness.log.traceflag=false
+ harness.log.delayseconds=1
+ harness.executeMode=2
+ harness.socket.retry.count=10
+-work.dir=/tmp/JTwork
+-report.dir=/tmp/JTreport
++
++#### BEGIN changes ####
++#work.dir=/tmp/JTwork
++#report.dir=/tmp/JTreport
++work.dir=@jmstck@/JTwork
++report.dir=@jmstck@/JTreport
++#### BEGIN changes ####
++
+ if.existing.work.report.dirs=auto
+
+ ###########################################################################
+@@ -198,8 +208,8 @@ porting.ts.jmsObjects.class.1=com.sun.ts.lib.implementation.sun.jms.SunRIJMSObje
+ #These properties are needed for the JMS tests.
+ ###############################################################
+ jms_timeout=10000
+-user=j2ee
+-password=j2ee
++user=@user@
++password=@password@
+
+ ######################################################################
+ ## Deliverables must set this property to the name of the deliverable
+@@ -232,7 +242,10 @@ platform.mode=standalone
+ #		or the Open Message Queue Product (impl.vi=ri).
+ #######################################################################################
+
++#### BEGIN changes ####
++#impl.vi=ri
+ impl.vi=ri
++#### END changes ####
+
+ # ---------------------------------------------------------------------------------
+ # ================================================

--- a/src/main/resources/jmstck_config.javax.patch
+++ b/src/main/resources/jmstck_config.javax.patch
@@ -1,0 +1,56 @@
+diff --git a/bin/ts.jte b/bin/ts.jte
+index 0e0da64..8731745 100644
+--- a/bin/ts.jte
++++ b/bin/ts.jte
+@@ -46,7 +46,11 @@
+ # Standalone JMS RI implementations. The JMS TCK has been run against both.
+ ####################################################################################
+ jms.home=
+-jms.classes=/home/jenkins/workspace/jakartaee-tck_master/glassfish5/glassfish/modules/jakarta.jms-api.jar
++
++#### BEGIN changes ####
++#jms.classes=/home/jenkins/workspace/jakartaee-tck_master/glassfish5/glassfish/modules/jakarta.jms-api.jar
++jms.classes=@client_libs@
++#### END changes ####
+
+ ####################################################################################
+ # The jars/classes for the TS harness/javatest and the test classes
+@@ -108,8 +112,14 @@ harness.log.traceflag=false
+ harness.log.delayseconds=1
+ harness.executeMode=2
+ harness.socket.retry.count=10
+-work.dir=/tmp/JTwork
+-report.dir=/tmp/JTreport
++
++#### BEGIN changes ####
++#work.dir=/tmp/JTwork
++#report.dir=/tmp/JTreport
++work.dir=@jmstck@/JTwork
++report.dir=@jmstck@/JTreport
++#### BEGIN changes ####
++
+ if.existing.work.report.dirs=auto
+
+ ###########################################################################
+@@ -198,8 +208,8 @@ porting.ts.jmsObjects.class.1=com.sun.ts.lib.implementation.sun.jms.SunRIJMSObje
+ #These properties are needed for the JMS tests.
+ ###############################################################
+ jms_timeout=10000
+-user=j2ee
+-password=j2ee
++user=@user@
++password=@password@
+
+ ######################################################################
+ ## Deliverables must set this property to the name of the deliverable
+@@ -232,7 +242,10 @@ platform.mode=standalone
+ #		or the Open Message Queue Product (impl.vi=ri).
+ #######################################################################################
+
++#### BEGIN changes ####
++#impl.vi=ri
+ impl.vi=ri
++#### END changes ####
+
+ # ---------------------------------------------------------------------------------
+ # ================================================

--- a/src/main/resources/jndi.properties
+++ b/src/main/resources/jndi.properties
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set the InitialContextFactory class to use
+java.naming.factory.initial=${java_naming_factory_initial}
+# additional defs only for Openwire
+${client == "ActiveMQClient" ? "" : "#"}java.naming.provider.url=${MyConnectionFactory}
+${clientJndiOpts}
+
+# Define the required ConnectionFactory instances
+${clientConnectionFactory}.MyConnectionFactory=${MyConnectionFactory}
+${clientConnectionFactory}.MyQueueConnectionFactory=${MyQueueConnectionFactory}
+${clientConnectionFactory}.MyTopicConnectionFactory=${MyTopicConnectionFactory}
+${clientConnectionFactory}.DURABLE_SUB_CONNECTION_FACTORY=${DURABLE_SUB_CONNECTION_FACTORY}
+# additional defs only for Openwire
+${client == "ActiveMQClient" ? "" : "#"}${clientConnectionFactory}.DURABLE_SUB_CONNECTION_FACTORY.brokerURL=${DURABLE_SUB_CONNECTION_FACTORY}
+${client == "ActiveMQClient" ? "" : "#"}${clientConnectionFactory}.DURABLE_SUB_CONNECTION_FACTORY.clientID=cts
+
+# Configure the necessary Queue and Topic objects
+queue.MY_QUEUE=${queue_prefix}MY_QUEUE
+queue.MY_QUEUE2=${queue_prefix}MY_QUEUE2
+queue.testQ0=${queue_prefix}testQ0
+queue.testQ1=${queue_prefix}testQ1
+queue.testQ2=${queue_prefix}testQ2
+queue.testQueue2=${queue_prefix}testQueue2
+queue.Q2=${queue_prefix}Q2
+
+topic.MY_TOPIC=${topic_prefix}MY_TOPIC
+topic.MY_TOPIC2=${topic_prefix}MY_TOPIC2
+topic.testT0=${topic_prefix}testT0
+topic.testT1=${topic_prefix}testT1
+topic.testT2=${topic_prefix}testT2
+
+# destinations for jms 2.0 tests, which were not mentioned in jndi file; see MSGQE-1411 and MSGQE-5188 for work notes
+# required to pass test_jms_tck_ipv4-com/sun/ts/tests/jms/core20/sessiontests/Client.java#autoCloseableTest
+queue.myQueue=myQueue
+topic.myTopic=myTopic

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,25 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+log4j.rootLogger=INFO, stdout
+
+log4j.logger.org.apache.qpid.jms=INFO
+
+# CONSOLE appender
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d [%-15.15t] - %-5p %-30.30c{1} - %m%n


### PR DESCRIPTION
Enhanced the Github Actions workflow by adding a manual trigger option and providing the capability to run a single Technology Compatibility Kit (TCK) test instead of the whole suite. This allows for more granular test control and improves debugging efficiency and flexibility. Made corresponding adjustments to the Gradle tasks and updated README.md accordingly. Also, updated the jmsClientVersion in the gradle.properties file for better compatibility with upstream changes.