### PR TITLE
Update authentication credentials for broker setup

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Start Artemis Broker in the background
       run: |
         podman pull ${{env.artemis_image}}
-        podman run -p 5672:5672 -e AMQ_USER=admin -e AMQ_PASSWORD=admin --rm -it ${{env.artemis_image}} &
+        podman run -p 5672:5672 -e AMQ_USER=tckuser -e AMQ_PASSWORD=tckuser --rm -it ${{env.artemis_image}} &
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Helper Gradle scripts to run Jakarta JMS TCK with ActiveMQ.
 
     yum install patch
 
+Suitable broker must be installed and configured.
+The config depends on client used, see `buildSrc/main/kotlin/*.kt` files for what is expected.
+Namely, clients are configured to log-in as tckuser/tckuser, and access the broker using default port for each protocol.
+
 ## Gradle Essentials
 
 Read the minimal introduction to Gradle which will be written soon.
@@ -102,9 +106,6 @@ go to `core/` or `core20/` and run `ant`
 
 # TODO:
 
-* integrate into Dtests
-    * use --project-cache-dir --no-daemon --refresh-dependencies gradle options
-* missing package installation
-* getting log4j, slf4j-log4j when mvnrepository is not available
-    * how to switch to .redhat-1 version?
-* copy gradle to ooo and download from there, or artifactory (gradle is 85MiB)
+* CI optimizations
+  * cache the gradle install between runs
+  * use --project-cache-dir --no-daemon --refresh-dependencies gradle options

--- a/buildSrc/src/main/kotlin/broker.kt
+++ b/buildSrc/src/main/kotlin/broker.kt
@@ -16,7 +16,7 @@
  */
 
 abstract class Broker {
-    val user = "tckuser"  // user and password; Dtests creates that on the broker
+    val user = "tckuser"  // default user and password
     val pass = "tckuser"
     open val queue_prefix = ""
     open val topic_prefix = ""


### PR DESCRIPTION
Changed the authentication credentials for Artemis Broker setup in the Gradle workflow file along with code commentary changes in the broker.kt file. These changes were required to maintain consistency in broker login credentials across all settings and to provide accurate instructions in the README about the broker setup. User and password has been updated to 'tckuser' and references to these changes have been included in the README for guidance. Also, outdated or redundant tasks in the TODO section of the README file have been managed for clarity.