### PR TITLE
Update maven repository configurations and queue provisioning docs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: build
+        arguments: build --warning-mode all
 
   # Executes a single TCK test with qpid-jms against ActiveMQ Artemis to demonstrate the scripts work.
   # https://github.com/artemiscloud/activemq-artemis-broker-image
@@ -63,7 +63,7 @@ jobs:
     - name: Prepare and configure TCKs with Gradle (but don't run it all)
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: prepareTckTask --scan
+        arguments: prepareTckTask
 
     - name: Run a single TCK test
       run: |

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ Helper Gradle scripts to run Jakarta JMS TCK with ActiveMQ.
 
 ## Prerequisites
 
-`patch` command needs to be installed
-
-    yum install patch
+### JMS broker
 
 Suitable broker must be installed and configured.
 The config depends on client used, see `buildSrc/main/kotlin/*.kt` files for what is expected.
 Namely, clients are configured to log-in as tckuser/tckuser, and access the broker using default port for each protocol.
+
+### patch command
+
+`patch` command needs to be installed
+
+    yum install patch
 
 ## Gradle Essentials
 
@@ -69,7 +73,7 @@ Which properties are required depends on the task. For example, properties `host
     * `activemq`  // ActiveMQ Classic
 
 * -PjmsClientVersion
-    * default is `+`, meaning latest upstream version, use something like `0.11.0.redhat-1`
+    * default is `+`, meaning latest available version
 
 * -Phost, optional
     * broker hostname (without port), default is `localhost`
@@ -77,14 +81,26 @@ Which properties are required depends on the task. For example, properties `host
 * -Pport, optional
     * broker port number, default depends on client, either `5672` or `61616`
 
-* <repository>
-  * -Pupstream
+* \<repository>
+  * `-Pmaven-central`
   * -Plocal
-    * maven local repository in `~/.m2/repository`
-  * -Psystem
-    * rpms installed to `file:///usr/share/java/maven-repo`
-  * -Prelease, -Pcandidate
-    * Red Hat public repositories for released versions
+    * enables locating jms client in maven local repository in `~/.m2/repository`
+  * `-PuberJar`
+    * adds this jar (with uberjar distribution of the client) to the classpath
+  * `-PflatDirs`, `-PrepoDirs`, `-PrepoUrls`,
+    * configures gradle to load a list of ; separated strings, pointing to
+      either load flat dir of jars,
+      or maven repositories on disk given by path (without `file://`),
+      or maven repositories given by their urls
+
+## Creating queues and topics
+
+There are helper tasks in `destinations.build.ks` that create necessary destinations on the topic.
+The AMQX tool available from https://github.com/rh-messaging/cli-java/tree/main/cli-activemq-jmx is used for this.
+
+Some JMS TCK tests do not require any destinations to be predeclared and will pass without doing this.
+
+If you don't want to use AMQX, create the destinations mentioned in the script manually using broker management tools.
 
 ## Return code
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@
 # so that the gradle project can be imported into IDE without having to deal
 # with errors caused by undefined variables when evaluating the script.
 
-jmsClientVersion=2.4.0
-upstream=
 jmsVersion=1.1
 jmsBroker=activemq-artemis
 jmsClient=qpid-jms
+jmsClientVersion=2.4.0
+maven-central=


### PR DESCRIPTION
Optimized Gradle configurations to enable easier usage of maven repositories and modified warning mode for build action. The build action now uses 'all' mode for warnings. Also tidied up the repository settings in Gradle configuration by adding new properties for easier handling of any required repository (local, maven-central etc.) and reducing redundant codes.

README.md got updated to better describe the use of these properties. 'patch' command installation instructions were moved to another location to emphasize focus on JMS broker installation. Also added instructions for creating queues and topics.

Lastly, order of properties in gradle.properties file were adjusted, with the addition of the maven-central property.

These changes have been made to simplify the setup process and making sure it's easy to understand and execute for even first-time users.